### PR TITLE
Fixed a comparison where the wrong driver will be displayed

### DIFF
--- a/doflicky/bundleset.py
+++ b/doflicky/bundleset.py
@@ -60,7 +60,7 @@ class BundleSet:
             otherDrivers = [x for x in self.uniqueDrivers if x.get_base() == b]
 
             for existing in otherDrivers:
-                if existing.get_priority() > driver:
+                if existing.get_priority() > driver.get_priority():
                     print("DEBUG: {} shadowed by existing {}".format(
                         driver.get_name(), existing.get_name()))
                     return


### PR DESCRIPTION
- Compared with the driver object and not the driver priority
- If that check was true, not only would a wrong error message be printed, but the function would return before the next check which would have made it appear to behave correctly